### PR TITLE
dsv/parser.scm: Correctly handle quoted final fields in CRLF context.

### DIFF
--- a/modules/dsv/parser.scm
+++ b/modules/dsv/parser.scm
@@ -69,7 +69,10 @@
            (number->string (object-address parser) 16))))
 
 (define (parser-read-line parser)
-  (read-line (parser-port parser)))
+  (let ((line (read-line (parser-port parser))))
+    (if (and (eqv? (parser-type parser) 'rfc4180) (not (eof-object? line)))
+        (string-trim-right line #\cr)
+        line)))
 
 (define (parser-string-split parser str)
   (string-split str (parser-delimiter parser)))

--- a/tests/rfc4180.scm
+++ b/tests/rfc4180.scm
@@ -37,6 +37,15 @@
                (call-with-input-string
                 "\"aaa\",\"b\"\"bb\",\"ccc\""
                 (cut dsv->scm <> #:format 'rfc4180)))
+       ;; Check handling of quoted final fields in CRLF context
+       (equal? '(("aaa"))
+               (call-with-input-string "\"aaa\"\r\n"
+                 (cut dsv->scm <> #:format 'rfc4180)))
+       (equal? '(("aaa" "bbb")
+                 ("c\"cc" "ddd")
+                 ("" "e\""))
+               (call-with-input-string "aaa,\"bbb\"\r\n\"c\"\"cc\",ddd\r\n,\"e\"\"\""
+                 (cut dsv->scm <> #:format 'rfc4180)))
        ;; Check handling of empty quoted strings.
        (equal? '((""))
                (call-with-input-string


### PR DESCRIPTION
* modules/dsv/parser.scm (parser-read-line): Trim \r if we are a 'rfc4180
  parser.
* tests/rfc4180.scm: Add tests for quoted final field handling.