### PR TITLE
Add Guile 3.0 as a possible GUILE_PKG

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AC_ARG_WITH([guilesitedir],
              esac],
              [guilesitedir=""])
 
-GUILE_PKG([2.0 2.2])
+GUILE_PKG([3.0 2.0 2.2])
 GUILE_PROGS
 GUILE_SITE_DIR
 


### PR DESCRIPTION
Currently building of guile-dsv using Guile 3.0 or higher fails because configure only checks for Guile 2.0 or 2.2.  Adding 3.0 as an option *should* fix this.