### PR TITLE
modules/dsv/table: ("format-table"): make row width configurable.

### DIFF
--- a/modules/dsv/table.scm
+++ b/modules/dsv/table.scm
@@ -316,9 +316,11 @@ sub-list of strings."
                      (width 80)
                      (borders '())
                      (padding 0)
-                     (string-slice string-slice))
+                     (string-slice string-slice)
+                     (calculate-cell-widths table-calculate-cell-widths))
   "Wrap a TABLE in such way that the table will fit into WIDTH
-columns using a procedure STRING-SLICE."
+columns using a procedure STRING-SLICE. The individual cell withs are
+calculated width a CALCULATE-CELL-WIDTHS procedure."
   (let* ((column-count (length (car table)))
          (border-left      (or (assoc-ref borders 'border-left) ""))
          (column-separator (or (assoc-ref borders 'column-separator) ""))
@@ -343,7 +345,7 @@ columns using a procedure STRING-SLICE."
          (percents (map (lambda (w)
                           (* (/ w current-total-width) 100.0))
                         current-column-widths))
-         (new-widths (table-calculate-cell-widths content-width percents))
+         (new-widths (calculate-cell-widths content-width percents))
          (new-total-width (sum new-widths)))
     (when (> (+ column-count extra-width) width)
       (table-error
@@ -464,12 +466,14 @@ columns using a procedure STRING-SLICE."
 (define* (format-table table
                        borders
                        #:key
+                       (calculate-cell-widths table-calculate-cell-widths)
                        (width #f)
                        (with-header? #f)
                        (port (current-output-port))
                        (string-slice string-slice))
   "Print a formatted TABLE to a PORT, using a BORDERS specification.  The table
-will be fit into the specified WIDTH using STRING-SLICE procedure."
+will be fit into the specified WIDTH using STRING-SLICE procedure, and the
+individual cell widths are calculated with a CALCULATE-CELL-WIDTHS procedure."
   (let* ((padding 0)
          (table  (if (and width (not (zero? width)))
                      (table-wrap table
@@ -477,7 +481,8 @@ will be fit into the specified WIDTH using STRING-SLICE procedure."
                                  #:borders borders
                                  #:width width
                                  #:padding padding
-                                 #:string-slice string-slice)
+                                 #:string-slice string-slice
+                                 #:calculate-cell-widths calculate-cell-widths)
                      table))
          (row-widths        (get-width table))
          (column-separator    (or (assoc-ref borders 'column-separator) ""))

--- a/tests/table.scm
+++ b/tests/table.scm
@@ -254,6 +254,52 @@
                 #:string-slice (lambda (s w)
                                  s))))
 
+(test-equal "table-wrap: Custom calculate-cell-widths"
+  (string-join
+   (list ".-----------------."
+         "| a1234 | b1 | c1 |"
+         "| 56789 | 23 | 23 |"
+         "| 0     | 45 | 45 |"
+         "|       | 67 | 67 |"
+         "|       | 89 | 89 |"
+         "|       | 0  | 0  |"
+         "|=======+====+====|"
+         "| a2345 | b2 | c2 |"
+         "| 67890 | 34 | 34 |"
+         "|       | 56 | 56 |"
+         "|       | 78 | 78 |"
+         "|       | 90 | 90 |"
+         "|-------+----+----|"
+         "| a3456 | b3 | c3 |"
+         "| 7890  | 45 | 45 |"
+         "|       | 67 | 67 |"
+         "|       | 89 | 89 |"
+         "|       | 0  | 0  |"
+         "|-------+----+----|"
+         "| a4567 | b4 | c4 |"
+         "| 890   | 56 | 56 |"
+         "|       | 78 | 78 |"
+         "|       | 90 | 90 |"
+         "'-----------------'"
+         "")
+   "\n")
+  (let* ((table '(("a1234567890" "b1234567890" "c1234567890")
+                  ("a234567890" "b234567890" "c234567890")
+                  ("a34567890" "b34567890" "c34567890")
+                  ("a4567890" "b4567890" "c4567890")))
+         (presets-path (string-append (getenv "abs_top_srcdir")
+                                      "/presets/"))
+         (preset (load-table-preset "ascii"
+                                    #:table-presets-path presets-path)))
+    (with-output-to-string
+      (lambda ()
+        (format-table table preset
+                      #:with-header? #t
+                      #:width 20
+                      #:calculate-cell-widths
+                      (lambda (content-width percents)
+                        (list 5 2 2)))))))
+
 (test-equal "table-format-row: simple formatting"
   " a  b  c \n"
   (let ((data '(("a" "b" "c"))))


### PR DESCRIPTION
* modules/dsv/table.scm (table-wrap, format-table): Add calculate-cell-widths option.
* tests/table.scm: ("table-wrap: Custom calculate-cell-widths"): New test.

This allows to very precisely control the width of each column.